### PR TITLE
Remove deadline from gometalinter

### DIFF
--- a/makefiles.md
+++ b/makefiles.md
@@ -181,6 +181,6 @@ xunit-tests: test-deps
 lint:
 	go get -u github.com/alecthomas/gometalinter
 	gometalinter --install
-	gometalinter ./... --deadline=30s > $(lint_output); true
+	gometalinter ./... > $(lint_output); true
 ```
 


### PR DESCRIPTION
30s is now gometalinter's default.
https://github.com/alecthomas/gometalinter/commit/9af851db896f6a62ceee990ba8a437ad807d1292