### PR TITLE
Update gometalinter install

### DIFF
--- a/makefiles.md
+++ b/makefiles.md
@@ -179,8 +179,7 @@ xunit-tests: test-deps
 
 .PHONY: lint
 lint:
-	go get -u github.com/alecthomas/gometalinter
-	gometalinter --install
+	go get -u gopkg.in/alecthomas/gometalinter.v2
 	gometalinter ./... > $(lint_output); true
 ```
 

--- a/makefiles.md
+++ b/makefiles.md
@@ -180,6 +180,6 @@ xunit-tests: test-deps
 .PHONY: lint
 lint:
 	go get -u gopkg.in/alecthomas/gometalinter.v2
-	gometalinter ./... > $(lint_output); true
+	gometalinter.v2 ./... > $(lint_output); true
 ```
 


### PR DESCRIPTION
Update gometalinter install to use stable version with vendored linters.