### PR TITLE
Bring style guide into line with historical practice

### DIFF
--- a/perl.md
+++ b/perl.md
@@ -58,4 +58,4 @@ Subs should be separated by dashed lines (hash, space, 78xdash)
 # ------------------------------------------------------------------------------
 ```
 
-Here's a vi key sequence for this → `(i)#(space)(esc)78(a)-(esc)` (easier than it looks :P)
+Here's a vi key sequence for this → `(i)#(space)(esc)77(a)-(esc)`


### PR DESCRIPTION
Bring style guide into line with historical practice

```
nshadrach@afal-drwg:chl-perl:SCRS-1376_edit_guarantor$ ack '^# -{78}$' $MODULES|wc -l
     178
nshadrach@afal-drwg:chl-perl:SCRS-1376_edit_guarantor$ ack '^# -{77}$' $MODULES|wc -l
   10333
```