### PR TITLE
Restore standard of camel case for packages and classes

### DIFF
--- a/perl.md
+++ b/perl.md
@@ -20,7 +20,7 @@ Thing                |Convention                                    |Examples
 Methods / functions  |snake_case                                    |`buy_cats()`, `to_string()`
 Variables            |snake_case                                    |`$her_name`, `%shopping_list`, `@team_sheet`
 Booleans             |snake_case with prefix (e.g. is_, can_, has_) |`$is_ready`, `$can_file`, `$has_multiple_entries`
-Classes and packages |Pascal Case                                   |`Animal::Mammal::ScaryLion`
+Classes and packages |Camel casee                                   |`StatementOfConsentToAct::editStatementOfConsentToAct`
 
 Control Structures
 ------------------


### PR DESCRIPTION
Virtually all packages in CHL have camel class. 
Switching to Pascal case will lead to confusion and inconsistency
