### PR TITLE
Remove deps from test-deps

### DIFF
--- a/makefiles.md
+++ b/makefiles.md
@@ -143,7 +143,7 @@ $(bin):
 	go build -o ./$(bin)
 
 .PHONY: test-deps
-test-deps: deps
+test-deps:
 	go get -t ./...
 
 .PHONY: test


### PR DESCRIPTION
No need for deps, because dependencies are pulled with the -t flag below.