### PR TITLE
Remove gometalinter

### DIFF
--- a/go.md
+++ b/go.md
@@ -15,7 +15,7 @@ Dev environments
 * If using vim, the vim-go plugin is recommended.
 * It’s a tricky one to have a policy for. It’s not realistic to say never commit code that golint or vet are complaining about, because sometimes they have false positives. But the majority of issues it flags up are important for maintaining code quality. Things like you MUST comment anything that is exported are very important to us.
 * Some source on the joys of go-fmt https://blog.golang.org/go-fmt-your-code
-* If you are a pedant, gometalinter is useful.
+* [golangci-lint](https://github.com/golangci/golangci-lint) should be used for linting.
 
 Method names
 ------------

--- a/makefiles.md
+++ b/makefiles.md
@@ -87,7 +87,6 @@ Target             |Purpose
 `test-compile`     |Run compilation tests for dynamic languages
 `publish`          |Publish a library artefact to an artefact store (e.g. Artifactory)
 `xunit-tests`      |Run unit tests and format output for parsing as xunit (for golang repo jenkins integration)
-`lint`             |Run lint checks
 
 **Additional targets**
 
@@ -176,10 +175,4 @@ dist: clean build package
 xunit-tests: test-deps
 	go get github.com/tebeka/go2xunit
 	@set -a; $(test_unit_env); go test -v $(TESTS) -run 'Unit' | go2xunit -output $(xunit_output)
-
-.PHONY: lint
-lint:
-	go get -u github.com/alecthomas/gometalinter
-	gometalinter --install
-	gometalinter ./... > $(lint_output); true
 ```


### PR DESCRIPTION
Gometalinter is deprecated. golangci-lint should be used in future.