### PR TITLE
Add test verification to Go Makefile styleguide

### DIFF
--- a/Makefiles/go_makefiles.md
+++ b/Makefiles/go_makefiles.md
@@ -66,6 +66,20 @@ test: test-unit
 .PHONY: test-unit
 test-unit:
 	  go test $(TESTS) -run 'Unit'
+
+.PHONY: test-verify
+test-verify: SHELL:=/bin/bash
+test-verify:
+	@invalid_tests=( $$(go test ./... -list=. | grep ^Test | grep -v "Unit" | grep -v "Integration") ); \
+    if [[ -n "$$invalid_tests" ]]; then \
+        echo "Fail: Tests must include 'Unit' or 'Integration' in the name:"; \
+        for test_name in $${invalid_tests[@]}; do \
+            echo " $${test_name}"; \
+        done; \
+        false; \
+    else \
+        echo "All tests are valid"; \
+    fi
 ```
 
 **Go service**
@@ -108,13 +122,23 @@ test: test-unit test-integration
 test-unit:
 	go test $(TESTS) -run 'Unit'
 
-.PHONY: test-util
-test-util:
-	go test $(TESTS) -run 'Util'
-
 .PHONY: test-integration
 test-integration:
 	$(source_env); go test $(TESTS) -run 'Integration'
+
+.PHONY: test-verify
+test-verify: SHELL:=/bin/bash
+test-verify:
+	@invalid_tests=( $$(go test ./... -list=. | grep ^Test | grep -v "Unit" | grep -v "Integration") ); \
+    if [[ -n "$$invalid_tests" ]]; then \
+        echo "Fail: Tests must include 'Unit' or 'Integration' in the name:"; \
+        for test_name in $${invalid_tests[@]}; do \
+            echo " $${test_name}"; \
+        done; \
+        false; \
+    else \
+        echo "All tests are valid"; \
+    fi
 
 .PHONY: clean
 clean:
@@ -131,7 +155,7 @@ package:
 .PHONY: dist
 dist: clean build package
 
-.PHONY: unit-tests
+.PHONY: xunit-tests
 xunit-tests:
 	go get github.com/tebeka/go2xunit
 	@set -a; $(test_unit_env); go test -v $(TESTS) -run 'Unit' | go2xunit -output $(xunit_output)


### PR DESCRIPTION
Go tests should be verified to make sure they contain either "Unit" or "Integration" in the name. This is required because the Go test runs are filtered using regexes.