### PR TITLE
Add coverprofile to Makefile examples in Testing

### DIFF
--- a/go.md
+++ b/go.md
@@ -73,7 +73,7 @@ Testing
 
 ```
 test-unit:
-    go test $(TESTS) -run 'Unit'
+    go test $(TESTS) -run 'Unit' -coverprofile=coverage.out
 
 test-integration:
     go test $(TESTS) -run 'Integration'


### PR DESCRIPTION
This change was already added to the Makefile styleguide, but as bsaunders pointed out, we need to fix this too.
Without this change, Sonar cannot see the coverage.