### PR TITLE
Remove references to gometalinter

### DIFF
--- a/Makefiles/go_makefiles.md
+++ b/Makefiles/go_makefiles.md
@@ -34,7 +34,6 @@ Target             |Purpose
 -------------------|-------
 `test-integration` |Run integration tests
 `xunit-tests`      |Run unit tests and format output for parsing as xunit (for golang repo jenkins integration)
-`lint`             |Run lint checks
 
 **Additional targets**
 
@@ -160,10 +159,4 @@ dist: clean build package
 xunit-tests:
 	go get github.com/tebeka/go2xunit
 	@set -a; $(test_unit_env); go test -v $(TESTS) -run 'Unit' | go2xunit -output $(xunit_output)
-
-.PHONY: lint
-lint:
-	go get -u github.com/alecthomas/gometalinter
-	gometalinter --install
-	gometalinter ./... > $(lint_output); true
 ```

--- a/go.md
+++ b/go.md
@@ -15,7 +15,7 @@ Dev environments
 * If using vim, the vim-go plugin is recommended.
 * It’s a tricky one to have a policy for. It’s not realistic to say never commit code that golint or vet are complaining about, because sometimes they have false positives. But the majority of issues it flags up are important for maintaining code quality. Things like you MUST comment anything that is exported are very important to us.
 * Some source on the joys of go-fmt https://blog.golang.org/go-fmt-your-code
-* If you are a pedant, gometalinter is useful.
+* [golangci-lint](https://github.com/golangci/golangci-lint) is a useful tool for local linting.
 
 Method names
 ------------


### PR DESCRIPTION
gometalinter is a deprecated tool - we now have Sonar 

This is a replacement for PR #36 