### PR TITLE
First cut of guidance on environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ A collection of standards for development at Companies House.
 -   [Health checks](health_check.md)
 -   [Feature flags](feature_flag.md)
 -   [READMEs](READMEs.md)
+-   [Environment variables](environment_variables.md)

--- a/environment_variables.md
+++ b/environment_variables.md
@@ -4,4 +4,4 @@ Micro services should be following [12 Factor App](https://12factor.net) princip
 ## Reading environment variables
 
 ### Java applications
-Teams may choose to use either Spring or the Companies House [environment-reader-library](https://github.com/companieshouse/environment-reader-library) library
+Teams may choose to use either Spring or the Companies House [environment-reader-library](https://github.com/companieshouse/environment-reader-library) library. How to use Spring application configuration is provide in the [Spring documention for external configuration](https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html)

--- a/environment_variables.md
+++ b/environment_variables.md
@@ -1,0 +1,7 @@
+# Environment Variables Guidelines
+
+Micro services should be following [12 Factor App](https://12factor.net) principles and reading their configuration from environment variables.
+## Reading environment variables
+
+### Java applications
+Teams may choose to use either Spring or the Companies House [environment-reader-library](https://github.com/companieshouse/environment-reader-library) library

--- a/environment_variables.md
+++ b/environment_variables.md
@@ -4,4 +4,6 @@ Micro services should be following [12 Factor App](https://12factor.net) princip
 ## Reading environment variables
 
 ### Java applications
-Teams may choose to use either Spring or the Companies House [environment-reader-library](https://github.com/companieshouse/environment-reader-library) library. How to use Spring application configuration is provide in the [Spring documention for external configuration](https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html)
+Teams may choose to use either Spring or the Companies House [environment-reader-library](https://github.com/companieshouse/environment-reader-library) library. They should be consistent in their choice for all the micro services that form a coherent group.
+
+How to use Spring application configuration is provide in the [Spring documention for external configuration](https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html)


### PR DESCRIPTION
First cut of guidance on environment variables indicating that for Java services teams can choose to use Spring or the Companies House environment-reader-library.