### PR TITLE
Correct the fix behaviour of markdownlint

### DIFF
--- a/.ci/bin/markdownlint
+++ b/.ci/bin/markdownlint
@@ -69,11 +69,11 @@ trap 'rm "${markdownlint_exec_script}"' EXIT
       "${CI_AWS_REGION}"
   fi
 
+  printf -- "markdownlint-cli2 "
+
   if [[ -n "${FIX_MARKDOWN}" ]]; then
     printf -- '%s ' '--fix'
   fi
-
-  printf -- "markdownlint-cli2 "
 
   if [[ -z "${markdown_file}" ]]; then
     markdown_globs=("./**/*.md" './*.md' '.ci/**/*.md')


### PR DESCRIPTION
--fix was being applied ahead of the markdownlint binary call therefore script failed with an error, the fix moves the `--fix` flag to after the program call.