### PR TITLE
Added style guide for integration branch naming

### DIFF
--- a/git/branches.md
+++ b/git/branches.md
@@ -5,9 +5,11 @@ Branch Naming Standards
 - Must not include the hash character `#`.
 - Should be descriptive (not just story/ticket number).
 - Can be prefixed like a URI.
+- Integration branch names should be in the format `feature/**/ci`
 
 Examples
 -------
 
 - `feature/scrs/painfully-complicated-feature`
 - `release/1.3.0`
+- `feature/project-name/ci`


### PR DESCRIPTION
Added style guide for integration branch naming

This will ensure that branch protection rules for integration branches can be applied to all integration branches using this naming format.