### PR TITLE
Add new guidelines for Chips Spring & Hibernate

### DIFF
--- a/standards/chips_development.md
+++ b/standards/chips_development.md
@@ -42,7 +42,7 @@ makes the code clearer.
 
 - Use `uk.gov.ch.chips.common.util.DateUtils` to generate dates in tests, in tandem with using `DateUtils` in the code. This prevents spurious errors in code caused by times ticking over. 
 
-```
+```java
     @BeforeClass
     public static void setupAll() {
         DateUtils.setDateFactory(new MockDateFactory(2026, 6, 29));
@@ -93,7 +93,8 @@ As of June 2026, Chips is using Hibernate 5.3. Hibernate 5 introduces support fo
 e.g. the Hibernate Criteria is deprecated in 5.3 and is removed in Hibernate 6. 
 
 We are currently using a 'getEntityManager' method that casts the existing Hibernate Session to an EntityManager. This is a temporary solution until we can fully migrate to JPA.
-```
+
+```java
     private EntityManager getEntityManager() {
         return sessionFactory.getCurrentSession();
     }

--- a/standards/chips_development.md
+++ b/standards/chips_development.md
@@ -4,10 +4,10 @@
 
 - To reduce future maintenance work, avoid using deprecated methods - both in
 CHIPS code and third-party packages.
-- Use the `uk.gov.ch.chips.common.util.DateUtils` class for generating
-dates.
+- Use the `uk.gov.ch.chips.common.util.DateUtils` class for generating dates.
 - Avoid `new Date()`; prefer `DateUtils.today()`.
 - Use methods in `DateUtils` where applicable.
+- Use the Apache `StringUtils` class for String comparisons e.g. `StringUtils.isBlank(x)`.
 
 ## Formatting
 
@@ -39,10 +39,30 @@ to simplify lookup.
 - Convert test classes using **EasyMock** to Mockito when modifying them.
 - Prefer `org.hamcrest.MatcherAssert.assertThat` over `assertTrue` when it
 makes the code clearer.
-- When testing CHIPS Rules, use the provided assertion methods where
-appropriate.
 
-#### Assertion Methods
+- Use `uk.gov.ch.chips.common.util.DateUtils` to generate dates in tests, in tandem with using `DateUtils` in the code. This prevents spurious errors in code caused by times ticking over. 
+
+```
+    @BeforeClass
+    public static void setupAll() {
+        DateUtils.setDateFactory(new MockDateFactory(2026, 6, 29));
+    }
+
+    @AfterClass
+    public static void tearDownAll() {
+        DateUtils.initializeDateFactory();
+    }
+    
+    @Test
+    public void testRule() {
+        Date myDate = DateUtils.today()
+    }
+```
+
+#### Testing Rules
+
+public abstract class AbstractChipsRuleTest {
+- When testing CHIPS Rules, use `` and the provided assertion methods where appropriate.
 
 These methods operate on the `testRule` instance variable and verify the number
 of issues detected:
@@ -68,11 +88,35 @@ include integration tests.
 
 - New code must have **at least 80% test coverage**.
 
+## Hibernate
+
+As of June 2026, Chips is using Hibernate 5.3. Hibernate 5 introduces support for JPA and native Hibernate operations are being deprecated 
+e.g. the Hibernate Criteria is deprecated in 5.3 and is removed in Hibernate 6. 
+
+We are currently using a 'getEntityManager' method that casts the existing Hibernate Session to an EntityManager. This is a temporary solution until we can fully migrate to JPA.
+```
+    private EntityManager getEntityManager() {
+        return sessionFactory.getCurrentSession();
+    }
+```
+
+- Prefer `getEntityManager` over `getCurrentSession` when possible.
+- Use JPA Query API instead of the JPA Criteria API unless predicates need to be added dynamically, as the query is simpler to use.
+- Use JPA methods e.g. `persist` and `merge` over the Hibernate methods e.g. `save` and `update`.
+
+- Use JPA Annotations for new entities instead of hbm.xml files. See `User` and `OrgUnit` for examples.
+
+- **Do not** use the Hibernate Criteria API.
+- **Do not** use @PersistenceContext to inject the EntityManager as this is not currently compatible with getCurrentSession in the same transaction.
+
 ## Spring
 
-- Use `JdbcTemplate.queryForObject()`,
-**do not** use `JdbcTemplate.queryForLong()` or
-`JdbcTemplate.queryForInt()` - these methods are deprecated.
+As of June 2026, Chips is using Spring 4.x. The server project (i.e. home to most Service and DAO classes) is configured to support annotations e.g. `@Component`.
 
-- **Avoid** using Spring's `HibernateTemplate` (deprecated).
-Use Hibernate `Session` methods instead.
+- Prefer Spring Annotations over XML configuration for code in the server project e.g. `@Component`, `@Autowired`, `@Value`, `@Qualifier`, `@Service`, `@Repository`, `@Controller`, etc.
+- Favour Construction Injection over Field Injection for Spring Beans and mark injected fields as final. This makes it easier to detect beans that have non-threadSafe variables.
+- Use `@Transactional` annotation instead of adding classes to the list in `spring-dao.xml` or `spring-transactions.xml`.
+- When converting old code to use annotations, remove all old config from xml files, including any transactional config from `spring-dao.xml` or `spring-transactions.xml`.
+ 
+- **Do not** using Spring's `HibernateTemplate` (deprecated). Use Hibernate/JPA `EntityManager` methods instead.
+- **Do not** extend base classes like `ChipsHibernateDaoSupport` or `AbstractChipsDao`. Use the `EntityManager` directly instead. This creates cleaner code which will be easier to migrate in the future.

--- a/standards/chips_development.md
+++ b/standards/chips_development.md
@@ -59,10 +59,9 @@ makes the code clearer.
     }
 ```
 
-#### Testing Rules
+### Testing Chips Rules
 
-public abstract class AbstractChipsRuleTest {
-- When testing CHIPS Rules, use `` and the provided assertion methods where appropriate.
+- When testing CHIPS Rules, use `AbstractChipsRuleTest` and the provided assertion methods where appropriate.
 
 These methods operate on the `testRule` instance variable and verify the number
 of issues detected:


### PR DESCRIPTION
Updates the Chips specific guidelines to cover the use of Spring and Hibernate as we migrate to newer versions.