### PR TITLE
Fixing broken links caused by adding folders to the Styleguides repo

### DIFF
--- a/checklists/one-off-checklist.md
+++ b/checklists/one-off-checklist.md
@@ -36,7 +36,7 @@ box which can be checked to identify these sections as not relevant.
 
 ## 2. README.md file
 
-[ReadMe standards are here](../READMEs.md)
+[ReadMe standards are here](/general/READMEs.md)
 
 - [ ] 2.1 - Present and adheres to standards
 - [ ] 2.2 - Contains a description and context for the repository

--- a/checklists/one-off-checklist.md
+++ b/checklists/one-off-checklist.md
@@ -29,7 +29,7 @@ box which can be checked to identify these sections as not relevant.
 - [ ] 1.5 - Pull Request template defined
 
   - [ ] 1.5.1 - Enforces to the
-    [Pull request style guide](../git/pull-requests.md)
+    [Pull request style guide](/git/pull-requests.md)
 
 - [ ] 1.6 - MIT License
 - [ ] 1.7 - Service name adheres to service naming guide

--- a/checklists/one-off-checklist.md
+++ b/checklists/one-off-checklist.md
@@ -54,7 +54,7 @@ repository but also to the Concourse pipeline which is held elsewhere)
 (Confluence links to follow for instructions for adding Dependency Track,
 Sonarqube, Dependency Check)
 
-[Concourse pipeline standards are here](../concourse_pipeline.md)
+[Concourse pipeline standards are here](/tools/concourse_pipeline.md)
 
 - [ ] 4.1 - Configured with GitHub Branch Protection rule
 - [ ] 4.2 - Concourse pipeline has unique Webhook tokens
@@ -72,7 +72,7 @@ Sonarqube, Dependency Check)
 
 ## 6. Makefiles
 
-[Makefiles standards are here](../makefiles.md)
+[Makefiles standards are here](/tools/makefiles.md)
 
 - [ ] 6.1 - Present in Repository
 

--- a/checklists/periodic-checklist.md
+++ b/checklists/periodic-checklist.md
@@ -24,7 +24,7 @@ box which can be checked to identify these sections as not relevant.
 
 ## 2. README.md
 
-[ReadMe standards are here](../READMEs.md)
+[ReadMe standards are here](/general/READMEs.md)
 
 - [ ] 2.1 - Contains up to date test instructions - do they work?
 - [ ] 2.2 - Contains up to date build, deploy and run instructions - do they work?
@@ -60,7 +60,7 @@ repository but also to the Concourse pipeline which is held elsewhere)
 (Confluence links to follow for instructions for adding Dependency Track,
 Sonarqube, Dependency Check)
 
-[Concourse pipeline standards are here](../concourse_pipeline.md)
+[Concourse pipeline standards are here](/tools/concourse_pipeline.md)
 
 - [ ] 4.1 - No old jobs in pipeline
 - [ ] 4.2 - Jobs are all passing
@@ -76,7 +76,7 @@ Sonarqube, Dependency Check)
 
 ## 6. Makefiles
 
-[Makefiles standards are here](../makefiles.md)
+[Makefiles standards are here](/tools/makefiles.md)
 
 - [ ] 6.1 - Adheres to styleguide
 - [ ] 6.2 - Contains targets: `all`, `clean`, `build`, `test`, `test-unit`,


### PR DESCRIPTION
This pull request updates several documentation links in the `one-off-checklist.md` and `periodic-checklist.md` files so they point to the correct resources.
